### PR TITLE
Restore sessions from disk and show HITL history

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If your browser page is accidentally refreshed during processing, you can resume
 2. Click **🔄 Refresh List** to see active sessions
 3. Select your session from the dropdown
 4. Click **▶️ Resume Selected Session**
-> ⚠️ Note: This only works if the server is still running. Server restart will clear all session data.
+> ⚠️ Note: If the server restarts, the app will attempt to restore sessions from `gradio_uploads`. This is best-effort and depends on saved logs/summaries, so some in-memory progress may be missing.
 
 
 ### Workflow

--- a/app.py
+++ b/app.py
@@ -666,6 +666,8 @@ def resume_session(session_id_to_resume, provider_choice, api_key):
         
         session = rebuttal_service.get_session(session_id_to_resume)
         if not session:
+            session = rebuttal_service.restore_session_from_disk(session_id_to_resume)
+        if not session:
             return (
                 gr.update(),
                 gr.update(),


### PR DESCRIPTION
之前服务一重启，网页里 “Resume Previous Session” 就空了；另外即使日志里有我们已经改过的反馈（比如 已经进行过人类回复修改），页面上也看不到。这里做了两个改动：

1. 启动后会从 gradio_uploads 自动把旧 session 读回内存，所以重启(关闭web server后端再打开)还能恢复。
2. 把 agent7_hitl_* 里的手动反馈也解析出来，Revision History 能显示真正改过的内容。