### PR TITLE
Add Requesty as an LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ export ZHIPUAI_API_BASE_URL='https://open.bigmodel.cn/api/paas/v4'
 
 export OPENROUTER_API_KEY=""
 export OPENROUTER_API_BASE_URL="https://openrouter.ai/api/v1"
+
+#requesty
+export REQUESTY_API_KEY=""
+export REQUESTY_API_BASE_URL="https://router.requesty.ai/v1"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Then edit `.env` and add your API key:
 # OpenRouter (supports many models)
 OPENROUTER_API_KEY=<your_openrouter_api_key>
 
+# Requesty (OpenAI-compatible router, supports many models)
+REQUESTY_API_KEY=<your_requesty_api_key>
+
 # Qwen (Alibaba DashScope)
 QWEN_API_KEY=<your_qwen_api_key>
 

--- a/app.py
+++ b/app.py
@@ -123,6 +123,12 @@ PROVIDER_CONFIGS = {
         "label": "OpenRouter API Key",
         "placeholder": "sk-or-v1-...",
     },
+    "Requesty": {
+        "provider_key": "requesty",
+        "env_var": "REQUESTY_API_KEY",
+        "label": "Requesty API Key",
+        "placeholder": "sk-...",
+    },
     "Qwen (DashScope)": {
         "provider_key": "qwen",
         "env_var": "QWEN_API_KEY",
@@ -162,6 +168,10 @@ MODEL_CHOICES_BY_PROVIDER = {
         "Grok 4.1 Fast": "x-ai/grok-4.1-fast",
         "GPT-5 Mini": "openai/gpt-5-mini",
         "DeepSeek V3.2": "deepseek/deepseek-chat-v3.2",
+        "Other models": "custom",
+    },
+    "Requesty": {
+        "GPT-4o Mini": "openai/gpt-4o-mini",
         "Other models": "custom",
     },
     "Qwen (DashScope)": {

--- a/llm.py
+++ b/llm.py
@@ -11,6 +11,11 @@ PROVIDER_CONFIGS: Dict[str, Dict[str, str]] = {
         "env_var": "OPENROUTER_API_KEY",
         "base_url_env_var": "OPENROUTER_API_BASE_URL",
     },
+    "requesty": {
+        "base_url": "https://router.requesty.ai/v1",
+        "env_var": "REQUESTY_API_KEY",
+        "base_url_env_var": "REQUESTY_API_BASE_URL",
+    },
     "qwen": {
         "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
         "env_var": "QWEN_API_KEY",
@@ -136,9 +141,9 @@ class LLMClient:
             
             self._genai = None
             
-            # Set up headers (OpenRouter needs special headers)
+            # Set up headers (OpenRouter/Requesty support optional attribution headers)
             extra_headers = {}
-            if self.provider == "openrouter":
+            if self.provider in ("openrouter", "requesty"):
                 extra_headers = {
                     "HTTP-Referer": site_url or "http://localhost",
                     "X-Title": site_name or "Rebuttal Assistant",


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as a provider, mirroring the existing OpenRouter provider.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router.

Changes (`llm.py`): add a `requesty` entry to `PROVIDER_CONFIGS` (base URL + `REQUESTY_API_KEY` + base-URL override env) and extend the optional attribution-header branch to cover Requesty. Plus `app.py` provider dropdown, `.env.example`, and README. Model naming is `provider/model`.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.